### PR TITLE
Add permission checks on the analytics

### DIFF
--- a/client/scripts/statistics.js
+++ b/client/scripts/statistics.js
@@ -3,9 +3,35 @@
 export async function renderStatistics(content) {
     content.innerHTML = await fetch("statistics.html").then(r => r.text());
 
-    const res = await fetch('/attendance/stats');
-    const stats = await res.json();
+    const response = await fetch('/attendance/stats', { method: 'GET' });
 
+    if (response.status === 403) {
+        content.innerHTML = `
+            <section class="stats-page">
+                <div class="error access-denied">
+                    <h2>Access Denied</h2>
+                    <p>You do not have permission to view attendance statistics.</p>
+                </div>
+            </section>
+        `;
+        return;
+    }
+
+    if (!response.ok) {
+        content.innerHTML = `
+            <section class="stats-page">
+                <div class="error">
+                    <h2>Error loading statistics</h2>
+                    <p>${response.status} - ${response.statusText}</p>
+                </div>
+            </section>
+        `;
+        return;
+    }
+
+    const stats = await response.json();
+
+    // Render charts
     zingchart.render({
         id: 'presenceRateChart',
         data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "packages": {
     "": {
       "dependencies": {
-        "connect-redis": "^9.0.0",
         "@opentelemetry/auto-instrumentations-node": "^0.67.2",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
         "@opentelemetry/sdk-node": "^0.208.0",
+        "connect-redis": "^9.0.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "express-session": "^1.18.2",

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -47,7 +47,7 @@ router.post("/end", requirePermission(PERMISSIONS.MANAGE_ALL_ATTENDANCE), endAtt
 //Scan students for who attended
 router.post("/scan", scanAttendance)
 
-router.get('/stats', getAttendanceStats);
+router.get('/stats', requirePermission(PERMISSIONS.MANAGE_ALL_ATTENDANCE), getAttendanceStats);
 
 
 // Show which students attended class (Professor view)


### PR DESCRIPTION
Restrict the `/stats` endpoint to the TA and Prof with `MANAGE_ALL_ATTENDANCE` permission

<img width="1374" height="623" alt="image" src="https://github.com/user-attachments/assets/d949b76a-df19-4804-9238-c72b5bb83d4c" />
